### PR TITLE
Undo処理の実装

### DIFF
--- a/board.cpp
+++ b/board.cpp
@@ -17,19 +17,19 @@ Board::Board(int tile_n, int initial_meeple_n)
 }
 
 Board::~Board() {
-  for (auto it = city_regions_.begin(); it != city_regions_.end(); it++) {
+  for (auto it = city_regions_.begin(); it != city_regions_.end(); ++it) {
     CityRegion* region = *it;
     delete region;
   }
-  for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); it++) {
+  for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); ++it) {
     CloisterRegion* region = *it;
     delete region;
   }
-  for (auto it = field_regions_.begin(); it != field_regions_.end(); it++) {
+  for (auto it = field_regions_.begin(); it != field_regions_.end(); ++it) {
     FieldRegion* region = *it;
     delete region;
   }
-  for (auto it = road_regions_.begin(); it != road_regions_.end(); it++) {
+  for (auto it = road_regions_.begin(); it != road_regions_.end(); ++it) {
     RoadRegion* region = *it;
     delete region;
   }
@@ -63,14 +63,14 @@ void Board::registerMeeple(MeepleColor color) {
   context_.registerMeeple(color);
 }
 
-bool Board::canPlaceTile(Tile* tile, int x, int y, int rotation) {
+bool Board::canPlaceTile(Tile* tile, int x, int y, int rotation) const {
   if (!tile_map_.isPlacablePosition(x, y)) {
     return false;
   }
   return adjacencyIsValid(tile, x, y, rotation);
 }
 
-bool Board::hasPossiblePlacement(Tile* tile) {
+bool Board::hasPossiblePlacement(Tile* tile) const {
   const std::set<BoardPosition>* positions = tile_map_.getPlacablePositions();
   for (auto it = positions->cbegin(); it != positions->cend(); it++) {
     BoardPosition pos(*it);
@@ -83,7 +83,7 @@ bool Board::hasPossiblePlacement(Tile* tile) {
   return false;
 }
 
-bool Board::adjacencyIsValid(Tile* tile, int x, int y, int rotation) {
+bool Board::adjacencyIsValid(Tile* tile, int x, int y, int rotation) const {
   Tile* top_tile = tile_map_.getPlacedTile(x, y + 1);
   if (top_tile != nullptr && !top_tile->canBottomAdjacentWith(tile, rotation)) {
     return false;
@@ -117,21 +117,21 @@ void Board::setInitialTile(Tile* tile, int rotation) {
   tile_map_.placeTile(tile, 0, 0);
   TilePlacementEvent* tile_event = new TilePlacementEvent(tile);
   const std::vector<Segment*>* city_segments = tile->getCitySegments();
-  for (auto it = city_segments->cbegin(); it != city_segments->cend(); it++) {
+  for (auto it = city_segments->cbegin(); it != city_segments->cend(); ++it) {
     Segment* s = *it;
     CityRegion* region = new CityRegion(region_id_++, s, this);
     city_regions_.push_back(region);
     tile_event->addGeneratedRegion(region);
   }
   const std::vector<Segment*>* field_segments = tile->getFieldSegments();
-  for (auto it = field_segments->cbegin(); it != field_segments->cend(); it++) {
+  for (auto it = field_segments->cbegin(); it != field_segments->cend(); ++it) {
     Segment* s = *it;
     FieldRegion* region = new FieldRegion(region_id_++, s, this);
     field_regions_.push_back(region);
     tile_event->addGeneratedRegion(region);
   }
   const std::vector<Segment*>* road_segments = tile->getRoadSegments();
-  for (auto it = road_segments->cbegin(); it != road_segments->cend(); it++) {
+  for (auto it = road_segments->cbegin(); it != road_segments->cend(); ++it) {
     Segment* s = *it;
     RoadRegion* region = new RoadRegion(region_id_++, s, this);
     road_regions_.push_back(region);
@@ -165,7 +165,7 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
   std::vector<Region*> adjacent_regions;
 
   const std::vector<Segment*>* city_segments = tile->getCitySegments();
-  for (auto it = city_segments->cbegin(); it != city_segments->cend(); it++) {
+  for (auto it = city_segments->cbegin(); it != city_segments->cend(); ++it) {
     Segment* my_s = *it;
     for (int d = 0; d < 4; d++) {
       if (around_tiles[d] == nullptr) {
@@ -205,7 +205,7 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
   }
 
   const std::vector<Segment*>* road_segments = tile->getRoadSegments();
-  for (auto it = road_segments->cbegin(); it != road_segments->cend(); it++) {
+  for (auto it = road_segments->cbegin(); it != road_segments->cend(); ++it) {
     Segment* my_s = *it;
     for (int d = 0; d < 4; d++) {
       if (around_tiles[d] == nullptr) {
@@ -245,7 +245,7 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
   }
 
   const std::vector<Segment*>* field_segments = tile->getFieldSegments();
-  for (auto it = field_segments->cbegin(); it != field_segments->cend(); it++) {
+  for (auto it = field_segments->cbegin(); it != field_segments->cend(); ++it) {
     Segment* my_s = *it;
     for (int d = 0; d < 8; d++) {
       if (around_tiles[d / 2] == nullptr) {
@@ -282,7 +282,7 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
     adjacent_regions.clear();
   }
 
-  for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); it++) {
+  for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); ++it) {
     CloisterRegion* region = *it;
     if (region->isCompleted() && !region->pointIsTransfered()) {
       region->transferPoint(&context_, true);
@@ -320,25 +320,25 @@ bool Board::placeMeeple(Segment* segment, MeepleColor color) {
 }
 
 void Board::transferRemainingPoints(bool return_meeple) {
-  for (auto it = city_regions_.begin(); it != city_regions_.end(); it++) {
+  for (auto it = city_regions_.begin(); it != city_regions_.end(); ++it) {
     CityRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
       region->transferPoint(&context_, return_meeple);
     }
   }
-  for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); it++) {
+  for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); ++it) {
     CloisterRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
       region->transferPoint(&context_, return_meeple);
     }
   }
-  for (auto it = field_regions_.begin(); it != field_regions_.end(); it++) {
+  for (auto it = field_regions_.begin(); it != field_regions_.end(); ++it) {
     FieldRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
       region->transferPoint(&context_, return_meeple);
     }
   }
-  for (auto it = road_regions_.begin(); it != road_regions_.end(); it++) {
+  for (auto it = road_regions_.begin(); it != road_regions_.end(); ++it) {
     RoadRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
       region->transferPoint(&context_, return_meeple);
@@ -391,44 +391,7 @@ void Board::undoPlaceTile(TilePlacementEvent* tile_event) {
   while (!generated_regions->empty()) {
     Region* generated_region = generated_regions->back();
     generated_regions->pop_back();
-    // TODO: リファクタリング(効率悪い(?)し、汚い)
-    switch (generated_region->getType()) {
-    case RegionType::CITY:
-      for (auto it2 = city_regions_.begin(); it2 != city_regions_.end(); ++it2) {
-	Region* region = *it2;
-	if (generated_region == region) {
-	  city_regions_.erase(it2);
-	  break;
-	}
-      }
-      break;
-    case RegionType::CLOISTER:
-      for (auto it2 = cloister_regions_.begin(); it2 != cloister_regions_.end(); ++it2) {
-	Region* region = *it2;
-	if (generated_region == region) {
-	  cloister_regions_.erase(it2);
-	  break;
-	}
-      }
-      break;
-    case RegionType::FIELD:
-      for (auto it2 = field_regions_.begin(); it2 != field_regions_.end(); ++it2) {
-	Region* region = *it2;
-	if (generated_region == region) {
-	  field_regions_.erase(it2);
-	  break;
-	}
-      }
-      break;
-    case RegionType::ROAD:
-      for (auto it2 = road_regions_.begin(); it2 != road_regions_.end(); ++it2) {
-	Region* region = *it2;
-	if (generated_region == region) {
-	  road_regions_.erase(it2);
-	  break;
-	}
-      }
-    }
+    removeRegionFromBoard(generated_region);
     delete generated_region;
   }
 
@@ -445,6 +408,50 @@ void Board::undoPlaceTile(TilePlacementEvent* tile_event) {
     }
     base_region->undoAddSegment(s);
   }
+}
+
+inline void Board::removeRegionFromBoard(Region* region_to_remove) {
+  // TODO: リファクタリング(効率悪い(?)し、汚い)
+  switch (region_to_remove->getType()) {
+  case RegionType::CITY:
+    for (auto it = city_regions_.begin(); it != city_regions_.end(); ++it) {
+      Region* region = *it;
+      if (region_to_remove == region) {
+        city_regions_.erase(it);
+        return;
+      }
+    }
+    break;
+  case RegionType::CLOISTER:
+    for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); ++it) {
+      Region* region = *it;
+      if (region_to_remove == region) {
+        cloister_regions_.erase(it);
+        return;
+      }
+    }
+    break;
+  case RegionType::FIELD:
+    for (auto it = field_regions_.begin(); it != field_regions_.end(); ++it) {
+      Region* region = *it;
+      if (region_to_remove == region) {
+        field_regions_.erase(it);
+        return;
+      }
+    }
+    break;
+  case RegionType::ROAD:
+    for (auto it = road_regions_.begin(); it != road_regions_.end(); ++it) {
+      Region* region = *it;
+      if (region_to_remove == region) {
+        road_regions_.erase(it);
+        return;
+      }
+    }
+    break;
+  }
+  // ここに到達してはいけない
+  assert(false);
 }
 
 void Board::undoPlaceMeeple(MeeplePlacementEvent* meeple_event) {

--- a/board.cpp
+++ b/board.cpp
@@ -189,8 +189,9 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
       auto it = adjacent_regions.cbegin();
       it++;
       for (; it != adjacent_regions.cend(); it++) {
-        region->mergeRegion(*it);
-	composition_event->addMergedRegion(*it);
+        if (region->mergeRegion(*it)) {
+	  composition_event->addMergedRegion(*it);
+	}
       }
       if (!region->meepleIsPlaced()) {
         meeple_place_candidates->push_back(my_s);
@@ -228,8 +229,9 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
       auto it = adjacent_regions.cbegin();
       it++;
       for (; it != adjacent_regions.cend(); it++) {
-        region->mergeRegion(*it);
-	composition_event->addMergedRegion(*it);
+        if (region->mergeRegion(*it)) {
+	  composition_event->addMergedRegion(*it);
+	}
       }
       if (!region->meepleIsPlaced()) {
         meeple_place_candidates->push_back(my_s);
@@ -268,8 +270,9 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
       auto it = adjacent_regions.cbegin();
       it++;
       for (; it != adjacent_regions.cend(); it++) {
-        region->mergeRegion(*it);
-	composition_event->addMergedRegion(*it);
+        if (region->mergeRegion(*it)) {
+	  composition_event->addMergedRegion(*it);
+	}
       }
       if (!region->meepleIsPlaced()) {
         meeple_place_candidates->push_back(my_s);
@@ -450,5 +453,6 @@ void Board::undoPlaceMeeple(MeeplePlacementEvent* meeple_event) {
   if (r->isCompleted() && r->pointIsTransfered()) {
     r->undoTransferPoint(&context_, true);
   }
-  s->undoPlaceMeeple();
+  MeepleColor placed_color = s->undoPlaceMeeple();
+  context_.returnMeeple(placed_color, 1);
 }

--- a/board.cpp
+++ b/board.cpp
@@ -11,7 +11,9 @@
 #include "tile.hpp"
 #include "utils.hpp"
 
-Board::Board(int tile_n) : region_id_(0), tile_map_(tile_n), placed_tiles_(), city_regions_(), cloister_regions_(), field_regions_(), road_regions_() {
+Board::Board(int tile_n, int initial_meeple_n)
+  : region_id_(0), tile_map_(tile_n), context_(initial_meeple_n), placement_events_(),
+  city_regions_(), cloister_regions_(), field_regions_(), road_regions_() {
 }
 
 Board::~Board() {
@@ -37,6 +39,10 @@ TilePositionMap* Board::getTilePositionMap() {
   return &tile_map_;
 }
 
+const GameContext* Board::getGameContext() const {
+  return &context_;
+}
+
 const std::vector<CityRegion*>* Board::getCityRegions() const {
   return &city_regions_;
 }
@@ -51,6 +57,10 @@ const std::vector<FieldRegion*>* Board::getFieldRegions() const {
 
 const std::vector<RoadRegion*>* Board::getRoadRegions() const {
   return &road_regions_;
+}
+
+void Board::registerMeeple(MeepleColor color) {
+  context_.registerMeeple(color);
 }
 
 bool Board::canPlaceTile(Tile* tile, int x, int y, int rotation) {
@@ -98,40 +108,46 @@ void Board::setInitialTile(Tile* tile) {
 }
 
 void Board::setInitialTile(Tile* tile, int rotation) {
-  if (placed_tiles_.size() != 0) {
+  if (placement_events_.size() != 0) {
     return;
   }
   tile->setX(0);
   tile->setY(0);
   tile->setRotation(rotation);
   tile_map_.placeTile(tile, 0, 0);
-  placed_tiles_.push_back(tile);
+  TilePlacementEvent* tile_event = new TilePlacementEvent(tile);
   const std::vector<Segment*>* city_segments = tile->getCitySegments();
   for (auto it = city_segments->cbegin(); it != city_segments->cend(); it++) {
     Segment* s = *it;
     CityRegion* region = new CityRegion(region_id_++, s, this);
     city_regions_.push_back(region);
+    tile_event->addGeneratedRegion(region);
   }
   const std::vector<Segment*>* field_segments = tile->getFieldSegments();
   for (auto it = field_segments->cbegin(); it != field_segments->cend(); it++) {
     Segment* s = *it;
     FieldRegion* region = new FieldRegion(region_id_++, s, this);
     field_regions_.push_back(region);
+    tile_event->addGeneratedRegion(region);
   }
   const std::vector<Segment*>* road_segments = tile->getRoadSegments();
   for (auto it = road_segments->cbegin(); it != road_segments->cend(); it++) {
     Segment* s = *it;
     RoadRegion* region = new RoadRegion(region_id_++, s, this);
     road_regions_.push_back(region);
+    tile_event->addGeneratedRegion(region);
   }
   Segment* cloister_segment = tile->getCloisterSegment();
   if (cloister_segment != nullptr) {
     CloisterRegion* region = new CloisterRegion(region_id_++, cloister_segment, this);
     cloister_regions_.push_back(region);
+    tile_event->addGeneratedRegion(region);
   }
+  PlacementEvent* event = new PlacementEvent(tile_event);
+  placement_events_.push_back(event);
 }
 
-bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segment*>* meeple_place_candidates, GameContext* context) {
+bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segment*>* meeple_place_candidates) {
   assert(meeple_place_candidates->size() == 0);
   if (!canPlaceTile(tile, x, y, rotation)) {
     return false;
@@ -140,7 +156,7 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
   tile->setY(y);
   tile->setRotation(rotation);
   tile_map_.placeTile(tile, x, y);
-  placed_tiles_.push_back(tile);
+  TilePlacementEvent* tile_event = new TilePlacementEvent(tile);
 
   Tile* around_tiles[4] = {
     tile_map_.getPlacedTile(x, y + 1), tile_map_.getPlacedTile(x + 1, y),
@@ -165,19 +181,24 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
       CityRegion* region = new CityRegion(region_id_++, my_s, this);
       city_regions_.push_back(region);
       meeple_place_candidates->push_back(my_s);
+      tile_event->addGeneratedRegion(region);
     } else {
       Region* region = adjacent_regions.at(0);
       region->addSegment(my_s);
+      RegionCompositionEvent* composition_event = new RegionCompositionEvent(my_s);
       auto it = adjacent_regions.cbegin();
       it++;
       for (; it != adjacent_regions.cend(); it++) {
         region->mergeRegion(*it);
+	composition_event->addMergedRegion(*it);
       }
       if (!region->meepleIsPlaced()) {
         meeple_place_candidates->push_back(my_s);
       } else if (region->isCompleted() && !region->pointIsTransfered()) {
-	region->transferPoint(context, true);
+	region->transferPoint(&context_, true);
+	tile_event->addCompletedRegion(region);
       }
+      tile_event->addRegionCompositionEvent(composition_event);
     }
     adjacent_regions.clear();
   }
@@ -199,19 +220,24 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
       RoadRegion* region = new RoadRegion(region_id_++, my_s, this);
       road_regions_.push_back(region);
       meeple_place_candidates->push_back(my_s);
+      tile_event->addGeneratedRegion(region);
     } else {
       Region* region = adjacent_regions.at(0);
       region->addSegment(my_s);
+      RegionCompositionEvent* composition_event = new RegionCompositionEvent(my_s);
       auto it = adjacent_regions.cbegin();
       it++;
       for (; it != adjacent_regions.cend(); it++) {
         region->mergeRegion(*it);
+	composition_event->addMergedRegion(*it);
       }
       if (!region->meepleIsPlaced()) {
         meeple_place_candidates->push_back(my_s);
       } else if (region->isCompleted() && !region->pointIsTransfered()) {
-	region->transferPoint(context, true);
+	region->transferPoint(&context_, true);
+	tile_event->addCompletedRegion(region);
       }
+      tile_event->addRegionCompositionEvent(composition_event);
     }
     adjacent_regions.clear();
   }
@@ -234,17 +260,21 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
       FieldRegion* region = new FieldRegion(region_id_++, my_s, this);
       field_regions_.push_back(region);
       meeple_place_candidates->push_back(my_s);
+      tile_event->addGeneratedRegion(region);
     } else {
       Region* region = adjacent_regions.at(0);
       region->addSegment(my_s);
+      RegionCompositionEvent* composition_event = new RegionCompositionEvent(my_s);
       auto it = adjacent_regions.cbegin();
       it++;
       for (; it != adjacent_regions.cend(); it++) {
         region->mergeRegion(*it);
+	composition_event->addMergedRegion(*it);
       }
       if (!region->meepleIsPlaced()) {
         meeple_place_candidates->push_back(my_s);
       }
+      tile_event->addRegionCompositionEvent(composition_event);
     }
     adjacent_regions.clear();
   }
@@ -252,7 +282,8 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
   for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); it++) {
     CloisterRegion* region = *it;
     if (region->isCompleted() && !region->pointIsTransfered()) {
-      region->transferPoint(context, true);
+      region->transferPoint(&context_, true);
+      tile_event->addCompletedRegion(region);
     }
   }
   Segment* cloister_segment = tile->getCloisterSegment();
@@ -260,47 +291,155 @@ bool Board::placeTile(Tile* tile, int x, int y, int rotation, std::vector<Segmen
     CloisterRegion* region = new CloisterRegion(region_id_++, cloister_segment, this);
     cloister_regions_.push_back(region);
     meeple_place_candidates->push_back(cloister_segment);
+    tile_event->addGeneratedRegion(region);
   }
 
+  PlacementEvent* event = new PlacementEvent(tile_event);
+  placement_events_.push_back(event);
   return true;
 }
 
-bool Board::placeMeeple(Segment* segment, MeepleColor color, GameContext* context) {
+bool Board::placeMeeple(Segment* segment, MeepleColor color) {
   Region* region = segment->getRegion();
   if (region->meepleIsPlaced()) {
     return false;
   }
   segment->placeMeeple(color);
-  context->placeMeeple(color);
+  context_.placeMeeple(color);
   if (region->isCompleted()) {
-    region->transferPoint(context, true);
+    region->transferPoint(&context_, true);
   }
+  MeeplePlacementEvent* meeple_event = new MeeplePlacementEvent(segment);
+  PlacementEvent* event = placement_events_.back();
+  assert(event->getMeeplePlacementEvent() == nullptr);
+  event->setMeeplePlacementEvent(meeple_event);
   return true;
 }
 
-void Board::transferRemainingPoints(GameContext* context, bool return_meeple) {
+void Board::transferRemainingPoints(bool return_meeple) {
   for (auto it = city_regions_.begin(); it != city_regions_.end(); it++) {
     CityRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
-      region->transferPoint(context, return_meeple);
+      region->transferPoint(&context_, return_meeple);
     }
   }
   for (auto it = cloister_regions_.begin(); it != cloister_regions_.end(); it++) {
     CloisterRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
-      region->transferPoint(context, return_meeple);
+      region->transferPoint(&context_, return_meeple);
     }
   }
   for (auto it = field_regions_.begin(); it != field_regions_.end(); it++) {
     FieldRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
-      region->transferPoint(context, return_meeple);
+      region->transferPoint(&context_, return_meeple);
     }
   }
   for (auto it = road_regions_.begin(); it != road_regions_.end(); it++) {
     RoadRegion* region = *it;
     if (!region->isMerged() && !region->pointIsTransfered()) {
-      region->transferPoint(context, return_meeple);
+      region->transferPoint(&context_, return_meeple);
     }
   }
+}
+
+bool Board::isUndoable() const {
+  // 最初のタイルはundoできない
+  return placement_events_.size() >= 2;
+}
+
+Tile* Board::undo() {
+  assert(isUndoable());
+  PlacementEvent* event = placement_events_.back();
+  placement_events_.pop_back();
+  MeeplePlacementEvent* meeple_event = event->getMeeplePlacementEvent();
+  if (meeple_event != nullptr) {
+    undoPlaceMeeple(meeple_event);
+  }
+  TilePlacementEvent* tile_event = event->getTilePlacementEvent();
+  undoPlaceTile(tile_event);
+  Tile* tile = tile_event->getTile();
+  tile_map_.undo(tile->getX(), tile->getY());
+  tile->setX(0);
+  tile->setY(0);
+  tile->setRotation(0);
+  delete event;
+  return tile;
+}
+
+void Board::undoPlaceTile(TilePlacementEvent* tile_event) {
+  std::vector<Region*>* completed_regions = tile_event->getCompletedRegions();
+  for (auto it = completed_regions->begin(); it != completed_regions->end(); ++it) {
+    Region* r = *it;
+    if (r->pointIsTransfered()) {
+      r->undoTransferPoint(&context_, true);
+    }
+  }
+  std::vector<Region*>* generated_regions = tile_event->getGeneratedRegions();
+  while (!generated_regions->empty()) {
+    Region* generated_region = generated_regions->back();
+    generated_regions->pop_back();
+    // TODO: リファクタリング(効率悪い(?)し、汚い)
+    switch (generated_region->getType()) {
+    case RegionType::CITY:
+      for (auto it2 = city_regions_.begin(); it2 != city_regions_.end(); ++it2) {
+	Region* region = *it2;
+	if (generated_region == region) {
+	  city_regions_.erase(it2);
+	  break;
+	}
+      }
+      break;
+    case RegionType::CLOISTER:
+      for (auto it2 = cloister_regions_.begin(); it2 != cloister_regions_.end(); ++it2) {
+	Region* region = *it2;
+	if (generated_region == region) {
+	  cloister_regions_.erase(it2);
+	  break;
+	}
+      }
+      break;
+    case RegionType::FIELD:
+      for (auto it2 = field_regions_.begin(); it2 != field_regions_.end(); ++it2) {
+	Region* region = *it2;
+	if (generated_region == region) {
+	  field_regions_.erase(it2);
+	  break;
+	}
+      }
+      break;
+    case RegionType::ROAD:
+      for (auto it2 = road_regions_.begin(); it2 != road_regions_.end(); ++it2) {
+	Region* region = *it2;
+	if (generated_region == region) {
+	  road_regions_.erase(it2);
+	  break;
+	}
+      }
+    }
+    delete generated_region;
+  }
+
+  std::vector<RegionCompositionEvent*>* comp_events = tile_event->getRegionCompositionEvents();
+  for (auto it = comp_events->begin(); it != comp_events->end(); ++it) {
+    RegionCompositionEvent* comp_event = *it;
+    Segment* s = comp_event->getAddedSegment();
+    Region* base_region = s->getRegion();
+    std::vector<Region*>* merged_regions = comp_event->getMergedRegions();
+    while (!merged_regions->empty()) {
+      Region* merged_region = merged_regions->back();
+      merged_regions->pop_back();
+      base_region->undoMergeRegion(merged_region);
+    }
+    base_region->undoAddSegment(s);
+  }
+}
+
+void Board::undoPlaceMeeple(MeeplePlacementEvent* meeple_event) {
+  Segment* s = meeple_event->getSegment();
+  Region* r = s->getRegion();
+  if (r->isCompleted() && r->pointIsTransfered()) {
+    r->undoTransferPoint(&context_, true);
+  }
+  s->undoPlaceMeeple();
 }

--- a/board.cpp
+++ b/board.cpp
@@ -343,6 +343,14 @@ void Board::transferRemainingPoints(bool return_meeple) {
   }
 }
 
+void Board::endTurn() {
+  context_.endTurn();
+}
+
+void Board::endGame() {
+  context_.endGame();
+}
+
 bool Board::isUndoable() const {
   // 最初のタイルはundoできない
   return placement_events_.size() >= 2;
@@ -360,6 +368,7 @@ Tile* Board::undo() {
   undoPlaceTile(tile_event);
   Tile* tile = tile_event->getTile();
   tile_map_.undo(tile->getX(), tile->getY());
+  endTurn();
   tile->setX(0);
   tile->setY(0);
   tile->setRotation(0);

--- a/board.hpp
+++ b/board.hpp
@@ -112,6 +112,20 @@ class PlacementEvent {
     MeeplePlacementEvent* meeple_event_;
 };
 
+
+// Boardクラスの利用方法:
+//  通常の利用方法
+//   1. 参加プレイヤーの数だけregisterMeepleを呼び出す
+//   2. setInitialTileを呼び出し初期タイルを配置する
+//   3. 各ターンの処理(タイルがなくなるまで以下を繰り返す)
+//       1. placeTileを呼び出しタイルを配置する
+//       2. ミープルを配置する場合はplaceMeepleを呼び出す
+//       3. endTurnを呼び出してターン終了処理を行う
+//   4. 全てのタイルを配置し終わったら、transferRemainingPointsを呼び出して残り得点の計算を行う
+//   5. endGameを呼び出してゲーム終了処理を行う
+// undoの利用方法
+//  - 3.3のendTurn呼び出し後のタイミングかundo呼び出し後に続けて呼び出すことができる
+//  - undo呼び出し後は前ターンのplaceTile呼び出し前の状態に戻っている
 class Board {
   public:
     Board(int tile_n, int initial_meeple_n);
@@ -134,7 +148,9 @@ class Board {
     void transferRemainingPoints(bool return_meeple);
     void endTurn();
     void endGame();
+    // undo可能かどうかを判定(setInitialTileで配置した処理タイルはundoできない)
     bool isUndoable() const;
+    // 返り値はundoによって配置が取り消されたTileへのポインタ
     Tile* undo();
   private:
     bool adjacencyIsValid(Tile* tile, int x, int y, int rotation) const;

--- a/board.hpp
+++ b/board.hpp
@@ -2,6 +2,7 @@
 #define __BOARD_HPP__
 
 #include <string>
+#include <vector>
 
 #include "game_context.hpp"
 #include "meeple_color.hpp"
@@ -19,29 +20,130 @@ class GameContext;
 class LargeTileHolder;
 class RoadRegion;
 
+class MeeplePlacementEvent {
+  public:
+    MeeplePlacementEvent(Segment* s) : s_(s) {};
+    ~MeeplePlacementEvent() {};
+    Segment* getSegment() const {
+      return s_;
+    };
+  private:
+    Segment* s_;
+};
+
+class RegionCompositionEvent {
+  public:
+    RegionCompositionEvent(Segment* added_segment)
+      : added_segment_(added_segment),  merged_regions_() {};
+    ~RegionCompositionEvent() {};
+    void addMergedRegion(Region* region) {
+      merged_regions_.push_back(region);
+    };
+    Segment* getAddedSegment() const {
+      return added_segment_;
+    };
+    std::vector<Region*>* getMergedRegions() {
+      return &merged_regions_;
+    };
+  private:
+    Segment* added_segment_;
+    std::vector<Region*> merged_regions_;
+};
+
+class TilePlacementEvent {
+  public:
+    TilePlacementEvent(Tile* tile)
+      : tile_(tile), generated_regions_(), events_(), completed_regions_() {};
+    ~TilePlacementEvent() {
+      for (auto it = events_.begin(); it != events_.end();) {
+	RegionCompositionEvent* event = *it;
+	it = events_.erase(it);
+	delete event;
+      }
+    };
+    Tile* getTile() const {
+      return tile_;
+    };
+    std::vector<Region*>* getGeneratedRegions() {
+      return &generated_regions_;
+    };
+    std::vector<RegionCompositionEvent*>* getRegionCompositionEvents() {
+      return &events_;
+    };
+    std::vector<Region*>* getCompletedRegions() {
+      return &completed_regions_;
+    };
+    void addGeneratedRegion(Region* region) {
+      generated_regions_.push_back(region);
+    };
+    void addRegionCompositionEvent(RegionCompositionEvent* event) {
+      events_.push_back(event);
+    };
+    void addCompletedRegion(Region* region) {
+      completed_regions_.push_back(region);
+    };
+  private:
+    Tile* tile_;
+    std::vector<Region*> generated_regions_;
+    std::vector<RegionCompositionEvent*> events_;
+    std::vector<Region*> completed_regions_;
+};
+
+
+class PlacementEvent {
+  public:
+    PlacementEvent(TilePlacementEvent* tile_event)
+      : tile_event_(tile_event), meeple_event_(nullptr) {};
+    ~PlacementEvent() {
+      delete tile_event_;
+      if (meeple_event_ != nullptr) {
+	delete meeple_event_;
+      }
+    };
+    TilePlacementEvent* getTilePlacementEvent() const {
+      return tile_event_;
+    };
+    MeeplePlacementEvent* getMeeplePlacementEvent() const {
+      return meeple_event_;
+    };
+    void setMeeplePlacementEvent(MeeplePlacementEvent* meeple_event) {
+      meeple_event_ = meeple_event;
+    };
+  private:
+    TilePlacementEvent* tile_event_;
+    MeeplePlacementEvent* meeple_event_;
+};
+
 class Board {
   public:
-    Board(int tile_n);
+    Board(int tile_n, int initial_meeple_n);
     ~Board();
     TilePositionMap* getTilePositionMap();
+    const GameContext* getGameContext() const;
     const std::vector<CityRegion*>* getCityRegions() const;
     const std::vector<CloisterRegion*>* getCloisterRegions() const;
     const std::vector<FieldRegion*>* getFieldRegions() const;
     const std::vector<RoadRegion*>* getRoadRegions() const;
+    void registerMeeple(MeepleColor color);
     bool canPlaceTile(Tile* tile, int x, int y, int rotation);
     bool hasPossiblePlacement(Tile* tile);
     void setInitialTile(Tile* tile);
     void setInitialTile(Tile* tile, int rotation);
     bool placeTile(Tile* tile, int x, int y, int rotation,
-      std::vector<Segment*>* meeple_place_candidates, GameContext* context);
-    bool placeMeeple(Segment* segment, MeepleColor color, GameContext* context);
+      std::vector<Segment*>* meeple_place_candidates);
+    bool placeMeeple(Segment* segment, MeepleColor color);
     // ゲーム終了後、残りの得点を計算するときに使う
-    void transferRemainingPoints(GameContext* context, bool return_meeple);
+    void transferRemainingPoints(bool return_meeple);
+    bool isUndoable() const;
+    Tile* undo();
   private:
     bool adjacencyIsValid(Tile* tile, int x, int y, int rotation);
+    void undoPlaceTile(TilePlacementEvent* tile_event);
+    void undoPlaceMeeple(MeeplePlacementEvent* meeple_event);
     int region_id_;
     TilePositionMap tile_map_;
-    std::vector<Tile*> placed_tiles_;
+    GameContext context_;
+    std::vector<PlacementEvent*> placement_events_;
     std::vector<CityRegion*> city_regions_;
     std::vector<CloisterRegion*> cloister_regions_;
     std::vector<FieldRegion*> field_regions_;

--- a/board.hpp
+++ b/board.hpp
@@ -132,6 +132,8 @@ class Board {
     bool placeMeeple(Segment* segment, MeepleColor color);
     // ゲーム終了後、残りの得点を計算するときに使う
     void transferRemainingPoints(bool return_meeple);
+    void endTurn();
+    void endGame();
     bool isUndoable() const;
     Tile* undo();
   private:

--- a/board.hpp
+++ b/board.hpp
@@ -123,8 +123,8 @@ class Board {
     const std::vector<FieldRegion*>* getFieldRegions() const;
     const std::vector<RoadRegion*>* getRoadRegions() const;
     void registerMeeple(MeepleColor color);
-    bool canPlaceTile(Tile* tile, int x, int y, int rotation);
-    bool hasPossiblePlacement(Tile* tile);
+    bool canPlaceTile(Tile* tile, int x, int y, int rotation) const;
+    bool hasPossiblePlacement(Tile* tile) const;
     void setInitialTile(Tile* tile);
     void setInitialTile(Tile* tile, int rotation);
     bool placeTile(Tile* tile, int x, int y, int rotation,
@@ -137,9 +137,10 @@ class Board {
     bool isUndoable() const;
     Tile* undo();
   private:
-    bool adjacencyIsValid(Tile* tile, int x, int y, int rotation);
+    bool adjacencyIsValid(Tile* tile, int x, int y, int rotation) const;
     void undoPlaceTile(TilePlacementEvent* tile_event);
     void undoPlaceMeeple(MeeplePlacementEvent* meeple_event);
+    void removeRegionFromBoard(Region* region);
     int region_id_;
     TilePositionMap tile_map_;
     GameContext context_;

--- a/board.hpp
+++ b/board.hpp
@@ -6,19 +6,17 @@
 
 #include "game_context.hpp"
 #include "meeple_color.hpp"
-#include "region.hpp"
-#include "segment.hpp"
-#include "tile.hpp"
 #include "tile_position_map.hpp"
 
-class Region;
+enum class MeepleColor;
+class Tile;
 class Segment;
+class Region;
 class CityRegion;
 class CloisterRegion;
 class FieldRegion;
-class GameContext;
-class LargeTileHolder;
 class RoadRegion;
+class GameContext;
 
 class MeeplePlacementEvent {
   public:

--- a/game.cpp
+++ b/game.cpp
@@ -4,7 +4,7 @@
 
 // TODO : n_players_ とタイルの種類はconfigファイルから読み込む
 Game::Game()
-  : turn_(0), n_players_(2), board_(72)
+  : turn_(0), n_players_(2), board_(72, 7)
 {
   //board_.setPile(tiles_);
   for (int pid = 0; pid < n_players_; ++pid) {

--- a/game_context.hpp
+++ b/game_context.hpp
@@ -3,10 +3,8 @@
 
 #include <unordered_map>
 
-#include "meeple_color.hpp"
-
+enum class MeepleColor;
 enum class RegionType;
-
 
 // ミープルの個数や得点を管理するためのクラス
 class GameContext {

--- a/game_context.hpp
+++ b/game_context.hpp
@@ -4,7 +4,6 @@
 #include <unordered_map>
 
 #include "meeple_color.hpp"
-#include "region.hpp"
 
 enum class RegionType;
 

--- a/player.hpp
+++ b/player.hpp
@@ -1,8 +1,6 @@
 #ifndef __PLAYER_HPP__
 #define __PLAYER_HPP__
 
-#include "board.hpp"
-
 // TODO: virturlクラスにして、継承したクラスで最低限の行動をするプレーヤーを実装する
 class Player {
   public:

--- a/region.cpp
+++ b/region.cpp
@@ -21,6 +21,7 @@ SegmentIterator::SegmentIterator(const Region* root, const Region* current,
 }
 
 SegmentIterator& SegmentIterator::operator++() {
+  // 深さ優先探索でRegionのツリーを移動しながら、全てのSegmentを辿っていく
   ++iter_;
   advanceToActualNext();
   return *this;

--- a/region.cpp
+++ b/region.cpp
@@ -114,7 +114,7 @@ SegmentIterator Region::segmentEnd() const {
 
 bool Region::mergeRegion(Region* region) {
   assert(getType() == region->getType());
-  if (this != region && !region->isMerged()) {
+  if (this != region && !isMerged() && !region->isMerged()) {
     for (auto it = region->segmentBegin(); it != region->segmentEnd(); ++it) {
       Segment* s = *it;
       s->setRegion(this);

--- a/region.cpp
+++ b/region.cpp
@@ -265,8 +265,14 @@ bool Region::pointIsTransfered() const {
 }
 
 void Region::debugPrint() const {
-  std::cout << "Region#" << id_ << "(" << isMerged() << "): ";
-  for (auto it = segments_.begin(); it != segments_.end(); ++it) {
+  std::cout << "Region#" << id_ << "(parent: ";
+  if (parent_ == nullptr) {
+    std::cout << "-";
+  } else {
+    std::cout << "Region#" << parent_->getId();
+  }
+  std::cout << "): ";
+  for (auto it = segmentBegin(); it != segmentEnd(); ++it) {
     Segment* s = *it;
     std::cout << s->getIndex() << "th ";
     std::cout << static_cast<int>(s->getType()) << " Segment of " << "Tile#" << s->getTile()->getId() << ", ";

--- a/region.cpp
+++ b/region.cpp
@@ -21,7 +21,7 @@ SegmentIterator::SegmentIterator(const Region* root, const Region* current,
 }
 
 SegmentIterator& SegmentIterator::operator++() {
-  iter_++;
+  ++iter_;
   advanceToActualNext();
   return *this;
 }
@@ -65,7 +65,7 @@ inline void SegmentIterator::setToEnd() {
 
 Region::Region(int id, Segment* segment, Board* board)
   : id_(id), board_(board), segments_(), meeple_placed_count_(0), winning_meeples_(),
-    parent_(nullptr), first_child_(nullptr), last_child_(nullptr), prev_sibling_(nullptr),
+    parent_(nullptr), last_child_(nullptr), prev_sibling_(nullptr),
     point_transfered_(false) {
   addSegment(segment);
 }
@@ -105,11 +105,11 @@ void Region::undoAddSegment(Segment* segment) {
 }
 
 SegmentIterator Region::segmentBegin() const {
-  return SegmentIterator(this, this, segments_.begin());
+  return std::move(SegmentIterator(this, this, segments_.begin()));
 }
 
 SegmentIterator Region::segmentEnd() const {
-  return SegmentIterator(this, this, segments_.end());
+  return std::move(SegmentIterator(this, this, segments_.end()));
 }
 
 bool Region::mergeRegion(Region* region) {
@@ -127,8 +127,8 @@ bool Region::mergeRegion(Region* region) {
 }
 
 inline void Region::appendChild(Region* region) {
-  if (first_child_ == nullptr) {
-    first_child_ = last_child_ = region;
+  if (last_child_ == nullptr) {
+    last_child_ = region;
   } else {
     region->prev_sibling_ = last_child_;
     last_child_ = region;
@@ -151,11 +151,7 @@ void Region::undoMergeRegion(Region* region) {
 inline void Region::removeLastChild() {
   Region* removed = last_child_;
   last_child_ = removed->prev_sibling_;
-  if (last_child_ == nullptr) {
-    first_child_ = nullptr;
-  } else {
-    removed->prev_sibling_ = nullptr;
-  }
+  removed->prev_sibling_ = nullptr;
   removed->parent_ = nullptr;
 }
 

--- a/region.cpp
+++ b/region.cpp
@@ -144,6 +144,7 @@ void Region::undoMergeRegion(Region* region) {
     s->setRegion(region);
   }
   removeLastChild();
+  meeple_placed_count_ -= region->meeple_placed_count_;
   rewindRegionState();
 }
 
@@ -166,13 +167,13 @@ void Region::meepleIsPlacedOnSegment(Segment* segment) {
   assert(segment->getRegion() == this);
   assert(segment->meepleIsPlaced());
   // TODO: 色毎にカウントする
-  meeple_placed_count_++;
+  ++meeple_placed_count_;
 }
 
 void Region::meepleIsUnplacedOnSegment(Segment* segment) {
   assert(segment->getRegion() == this);
   assert(!segment->meepleIsPlaced());
-  meeple_placed_count_++;
+  --meeple_placed_count_;
 }
 
 bool Region::meepleIsPlaced() const {

--- a/region.cpp
+++ b/region.cpp
@@ -42,19 +42,12 @@ inline void SegmentIterator::advanceToActualNext() {
   if (iter_ != current_->segments_.end()) {
     return;
   }
-  if (current_->first_child_ != nullptr) {
-    current_ = current_->first_child_;
+  if (current_->last_child_ != nullptr) {
+    current_ = current_->last_child_;
     iter_ = current_->segments_.begin();
     return;
    }
-  if (current_->prev_sibling_ != nullptr) {
-    current_ = current_->prev_sibling_;
-    iter_ = current_->segments_.begin();
-    return;
-  }
-  for (Region* region = current_->parent_;
-       region != nullptr && region != root_;
-       region = region->parent_) {
+  for (const Region* region = current_; region != root_; region = region->parent_) {
     if (region->prev_sibling_ != nullptr) {
       current_ = region->prev_sibling_;
       iter_ = current_->segments_.begin();

--- a/region.hpp
+++ b/region.hpp
@@ -73,7 +73,6 @@ class Region {
     int meeple_placed_count_;
     std::vector<MeepleColor> winning_meeples_;
     Region* parent_;
-    Region* first_child_;
     Region* last_child_;
     Region* prev_sibling_;
     bool point_transfered_;

--- a/region.hpp
+++ b/region.hpp
@@ -3,10 +3,6 @@
 
 #include <vector>
 
-#include "board.hpp"
-#include "game_context.hpp"
-#include "segment.hpp"
-
 class Board;
 class GameContext;
 class Segment;
@@ -15,6 +11,25 @@ enum class RegionType {
   CITY, CLOISTER, ROAD, FIELD
 };
 
+class Region;
+
+class SegmentIterator {
+  public:
+    friend Region;
+    SegmentIterator(const SegmentIterator& iter);
+    SegmentIterator& operator++();
+    Segment* operator*();
+    bool operator==(const SegmentIterator& iter);
+    bool operator!=(const SegmentIterator& iter);
+  private:
+    SegmentIterator(const Region* root, const Region* current,
+      std::vector<Segment*>::const_iterator iter);
+    void advanceToActualNext();
+    void setToEnd();
+    const Region* root_;
+    const Region* current_;
+    std::vector<Segment*>::const_iterator iter_;
+};
 
 // 複数のセグメントが繋がってできる領域を表すクラス
 // Regionは抽象クラスになっており、具象クラスとして
@@ -23,8 +38,7 @@ enum class RegionType {
 // それぞれ、得点の計算方法や完成の条件が違っている
 class Region {
   public:
-    class SegmentIterator;
-    class MeeplePlacedSegmentIterator;
+    friend SegmentIterator;
     Region(int id, Segment* segment, Board* board);
     virtual ~Region();
     int getId() const;
@@ -52,24 +66,6 @@ class Region {
     virtual int calculatePoint() = 0;
     virtual RegionType getType() const = 0;
     void debugPrint() const;
-    class SegmentIterator {
-      public:
-        friend Region;
-        SegmentIterator(const SegmentIterator& iter);
-        SegmentIterator& operator++();
-        Segment* operator*();
-        bool operator==(const SegmentIterator& iter);
-        bool operator!=(const SegmentIterator& iter);
-      private:
-        SegmentIterator(const Region* start, const Region* current,
-	  std::vector<Segment*>::const_iterator iter);
-        void advanceToActualNext();
-        void setToEnd();
-        const Region* start_;
-        const Region* current_;
-        std::vector<Segment*>::const_iterator iter_;
-    };
-    friend SegmentIterator;
   protected:
     int id_;
     Board* board_;

--- a/region.hpp
+++ b/region.hpp
@@ -80,6 +80,7 @@ class Region {
     void appendChild(Region* region);
     void removeLastChild();
     // undoAddSegmentやundoMergeRegionが呼ばれてRegionの構成が変化したときに呼び出される
+    // (undoAddSegmentやundoMergeRegionの中から呼ばれる)
     virtual void rewindRegionState() = 0;
 };
 

--- a/region.hpp
+++ b/region.hpp
@@ -44,7 +44,9 @@ class Region {
     // 置いているミープルの数が多い色を返す(同数の場合、複数の色を返す)
     void getWinningMeeples(std::vector<MeepleColor>* winning_meeples) const;
     void returnMeeples(GameContext* context);
+    void undoReturnMeeples(GameContext* context);
     void transferPoint(GameContext* context, bool return_meeple);
+    void undoTransferPoint(GameContext* context, bool undo_return_meeple);
     bool pointIsTransfered() const;
     virtual bool isCompleted() = 0;
     virtual int calculatePoint() = 0;
@@ -69,8 +71,6 @@ class Region {
     };
     friend SegmentIterator;
   protected:
-    void appendChild(Region* region);
-    void removeLastChild();
     int id_;
     Board* board_;
     std::vector<Segment*> segments_;
@@ -81,6 +81,11 @@ class Region {
     Region* last_child_;
     Region* prev_sibling_;
     bool point_transfered_;
+  private:
+    void appendChild(Region* region);
+    void removeLastChild();
+    // undoAddSegmentやundoMergeRegionが呼ばれてRegionの構成が変化したときに呼び出される
+    virtual void rewindRegionState() = 0;
 };
 
 class CityRegion : public Region {
@@ -90,6 +95,7 @@ class CityRegion : public Region {
     int calculatePoint();
     RegionType getType() const;
   private:
+    void rewindRegionState();
     bool completed_;
 };
 
@@ -100,6 +106,7 @@ class CloisterRegion : public Region {
     int calculatePoint();
     RegionType getType() const;
   private:
+    void rewindRegionState();
     bool completed_;
 };
 
@@ -113,6 +120,7 @@ class FieldRegion : public Region {
     RegionType getType() const;
     bool isAdjacentWith(const CityRegion* city_region);
   private:
+    void rewindRegionState();
     bool completed_;
 };
 
@@ -123,6 +131,7 @@ class RoadRegion : public Region {
     int calculatePoint();
     RegionType getType() const;
   private:
+    void rewindRegionState();
     bool completed_;
 };
 

--- a/segment.cpp
+++ b/segment.cpp
@@ -74,7 +74,7 @@ void Segment::placeMeeple(MeepleColor meeple) {
   region_->meepleIsPlacedOnSegment(this);
 }
 
-void Segment::unplaceMeeple() {
+void Segment::undoPlaceMeeple() {
   assert(placed_meeple_ != MeepleColor::NOT_PLACED);
   assert(region_ != nullptr);
   placed_meeple_ = MeepleColor::NOT_PLACED;

--- a/segment.cpp
+++ b/segment.cpp
@@ -75,11 +75,13 @@ void Segment::placeMeeple(MeepleColor meeple) {
   region_->meepleIsPlacedOnSegment(this);
 }
 
-void Segment::undoPlaceMeeple() {
+MeepleColor Segment::undoPlaceMeeple() {
   assert(placed_meeple_ != MeepleColor::NOT_PLACED);
   assert(region_ != nullptr);
+  MeepleColor placed = placed_meeple_;
   placed_meeple_ = MeepleColor::NOT_PLACED;
   region_->meepleIsUnplacedOnSegment(this);
+  return placed;
 }
 
 MeepleColor Segment::getPlacedMeeple() const {

--- a/segment.cpp
+++ b/segment.cpp
@@ -6,7 +6,7 @@
 #include "utils.hpp"
 
 Segment::Segment(int index, SegmentType type, bool has_pennant) :
-  index_(index), type_(type), has_pennant_(has_pennant), placed_meeple_(MeepleColor::NOT_PLACED) {
+  index_(index), type_(type), tile_(nullptr), region_(nullptr), has_pennant_(has_pennant), placed_meeple_(MeepleColor::NOT_PLACED) {
 }
 
 int Segment::getIndex() const {
@@ -31,6 +31,11 @@ Region* Segment::getRegion() const {
 
 void Segment::setRegion(Region* region) {
   region_ = region;
+}
+
+void Segment::unsetRegion() {
+  assert(region_ != nullptr);
+  region_ = nullptr;
 }
 
 bool Segment::hasPennant() const {
@@ -63,8 +68,17 @@ bool Segment::isAdjacentTo(int direction) const {
 
 void Segment::placeMeeple(MeepleColor meeple) {
   assert(meeple != MeepleColor::NOT_PLACED);
+  assert(placed_meeple_ == MeepleColor::NOT_PLACED);
+  assert(region_ != nullptr);
   placed_meeple_ = meeple;
   region_->meepleIsPlacedOnSegment(this);
+}
+
+void Segment::unplaceMeeple() {
+  assert(placed_meeple_ != MeepleColor::NOT_PLACED);
+  assert(region_ != nullptr);
+  placed_meeple_ = MeepleColor::NOT_PLACED;
+  region_->meepleIsUnplacedOnSegment(this);
 }
 
 MeepleColor Segment::getPlacedMeeple() const {

--- a/segment.cpp
+++ b/segment.cpp
@@ -1,5 +1,6 @@
 #include <cassert>
 
+#include "meeple_color.hpp"
 #include "region.hpp"
 #include "segment.hpp"
 #include "tile.hpp"

--- a/segment.hpp
+++ b/segment.hpp
@@ -22,17 +22,19 @@ class Segment {
     void setTile(Tile* tile);
     Region* getRegion() const;
     void setRegion(Region* region);
+    void unsetRegion();
     bool hasPennant() const;
     bool isAdjacentTo(int direction) const;
     void placeMeeple(MeepleColor meeple);
+    void unplaceMeeple();
     MeepleColor getPlacedMeeple() const;
     bool meepleIsPlaced() const;
   private:
-    int index_;
-    SegmentType type_;
+    const int index_;
+    const SegmentType type_;
     Tile* tile_;
     Region* region_;
-    bool has_pennant_;
+    const bool has_pennant_;
     MeepleColor placed_meeple_;
 };
 

--- a/segment.hpp
+++ b/segment.hpp
@@ -1,10 +1,7 @@
 #ifndef __SEGMENT_HPP__
 #define __SEGMENT_HPP__
 
-#include "meeple_color.hpp"
-#include "region.hpp"
-#include "tile.hpp"
-
+enum class MeepleColor;
 class Region;
 class Tile;
 

--- a/segment.hpp
+++ b/segment.hpp
@@ -23,7 +23,7 @@ class Segment {
     bool hasPennant() const;
     bool isAdjacentTo(int direction) const;
     void placeMeeple(MeepleColor meeple);
-    void undoPlaceMeeple();
+    MeepleColor undoPlaceMeeple();
     MeepleColor getPlacedMeeple() const;
     bool meepleIsPlaced() const;
   private:

--- a/segment.hpp
+++ b/segment.hpp
@@ -26,7 +26,7 @@ class Segment {
     bool hasPennant() const;
     bool isAdjacentTo(int direction) const;
     void placeMeeple(MeepleColor meeple);
-    void unplaceMeeple();
+    void undoPlaceMeeple();
     MeepleColor getPlacedMeeple() const;
     bool meepleIsPlaced() const;
   private:

--- a/tile.hpp
+++ b/tile.hpp
@@ -4,8 +4,6 @@
 #include <string>
 #include <vector>
 
-#include "segment.hpp"
-
 class Segment;
 
 enum class BorderType {

--- a/tile_factory.hpp
+++ b/tile_factory.hpp
@@ -5,9 +5,10 @@
 #include <string>
 
 #include "json.hpp"
-#include "tile.hpp"
 
 using json = nlohmann::json;
+
+class Tile;
 
 // タイルの名前を元にタイルを生成するクラス
 // 最初にJSONファイルからタイルの情報を読み込む

--- a/tile_position_map.cpp
+++ b/tile_position_map.cpp
@@ -88,6 +88,7 @@ Tile* TilePositionMap::undo(int x, int y) {
   int i = convertToIndex(x, y);
   Tile* tile = tiles_[i];
   tiles_[i] = nullptr;
+  checkAndAddPlacablePosition(x, y);
   checkAndRemovePlacablePosition(x, y + 1);
   checkAndRemovePlacablePosition(x + 1, y);
   checkAndRemovePlacablePosition(x, y - 1);

--- a/tile_position_map.cpp
+++ b/tile_position_map.cpp
@@ -52,6 +52,7 @@ TilePositionMap::~TilePositionMap() {
 
 void TilePositionMap::placeTile(Tile* tile, int x, int y) {
   assert(tile != nullptr);
+  assert(!isTilePlaced(x, y));
   BoardPosition pos(x, y);
   int i = convertToIndex(x, y);
   tiles_[i] = tile;
@@ -82,10 +83,30 @@ bool TilePositionMap::isPlacablePosition(int x, int y) const {
   return it != placables_.end();
 }
 
+Tile* TilePositionMap::undo(int x, int y) {
+  assert(isTilePlaced(x, y));
+  int i = convertToIndex(x, y);
+  Tile* tile = tiles_[i];
+  tiles_[i] = nullptr;
+  checkAndRemovePlacablePosition(x, y + 1);
+  checkAndRemovePlacablePosition(x + 1, y);
+  checkAndRemovePlacablePosition(x, y - 1);
+  checkAndRemovePlacablePosition(x - 1, y);
+  return tile;
+}
+
 inline void TilePositionMap::checkAndAddPlacablePosition(int x, int y) {
   if (!isTilePlaced(x, y)) {
     BoardPosition pos(x, y);
     placables_.insert(pos);
+  }
+}
+
+inline void TilePositionMap::checkAndRemovePlacablePosition(int x, int y) {
+  if (!isTilePlaced(x, y + 1) && !isTilePlaced(x + 1, y) &&
+      !isTilePlaced(x, y - 1) && !isTilePlaced(x - 1, y)) {
+    BoardPosition pos(x, y);
+    placables_.erase(pos);
   }
 }
 

--- a/tile_position_map.hpp
+++ b/tile_position_map.hpp
@@ -36,12 +36,14 @@ class TilePositionMap {
     // (x, y)にタイルを置くことが可能ならtrueを返す。
     // 置くことが可能の意味はgetPlacablePositionsと同じ。
     bool isPlacablePosition(int x, int y) const;
+    Tile* undo(int x, int y);
   private:
     int size_;
     int shift_;
     Tile** tiles_;
     std::set<BoardPosition> placables_;
     void checkAndAddPlacablePosition(int x, int y);
+    void checkAndRemovePlacablePosition(int x, int y);
     int convertToIndex(int x, int y) const;
 };
 

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -480,31 +480,93 @@ void board_tests() {
   board.registerMeeple(MeepleColor::GREEN);
   std::vector<Segment*> meeple_place_candidates;
 
+  Tile* tile = nullptr;
   Tile* tile0 = tile_factory.newFromName("D", 0);
   Tile* tile1 = tile_factory.newFromName("E", 1);
   Tile* tile2 = tile_factory.newFromName("C", 2);
   Tile* tile3 = tile_factory.newFromName("B", 3);
   Tile* tile4 = tile_factory.newFromName("U", 4);
 
+  // turn 0
   board.setInitialTile(tile0, 3);
-  test_assert("board_tests#0", board.canPlaceTile(tile1, 0, 1, 2));
-  board.placeTile(tile1, 0, 1, 2, &meeple_place_candidates);
-  test_assert("board_tests#1", meeple_place_candidates.size() == 2);
-  meeple_place_candidates.clear();
-  test_assert("board_tests#2", !board.hasPossiblePlacement(tile2));
-  test_assert("board_tests#3", board.canPlaceTile(tile3, 1, 1, 0));
-  board.placeTile(tile3, 1, 1, 0, &meeple_place_candidates);
-  test_assert("board_tests#4", meeple_place_candidates.size() == 2);
-  meeple_place_candidates.clear();
-  test_assert("board_tests#5", board.canPlaceTile(tile4, -1, 0, 1));
-  board.placeTile(tile4, -1, 0, 1, &meeple_place_candidates);
-  test_assert("board_tests#6", meeple_place_candidates.size() == 3);
-  meeple_place_candidates.clear();
+  test_assert("board_tests#0.0", count_unmerged_region<CityRegion>(board.getCityRegions()) == 1);
+  test_assert("board_tests#0.1", count_unmerged_region<CloisterRegion>(board.getCloisterRegions()) == 0);
+  test_assert("board_tests#0.2", count_unmerged_region<FieldRegion>(board.getFieldRegions()) == 2);
+  test_assert("board_tests#0.3", count_unmerged_region<RoadRegion>(board.getRoadRegions()) == 1);
+  test_assert("board_tests#0.4", board.getGameContext()->getTotalPoint(MeepleColor::RED) == 0);
+  test_assert("board_tests#0.5", board.getGameContext()->getTotalPoint(MeepleColor::GREEN) == 0);
+  test_assert("board_tests#0.6", board.getGameContext()->getHoldingMeepleCount(MeepleColor::RED) == 7);
+  test_assert("board_tests#0.7", board.getGameContext()->getHoldingMeepleCount(MeepleColor::GREEN) == 7);
 
-  test_assert("board_tests#7", count_unmerged_region<CityRegion>(board.getCityRegions()) == 1);
-  test_assert("board_tests#8", count_unmerged_region<CloisterRegion>(board.getCloisterRegions()) == 1);
-  test_assert("board_tests#9", count_unmerged_region<FieldRegion>(board.getFieldRegions()) == 3);
-  test_assert("board_tests#10", count_unmerged_region<RoadRegion>(board.getRoadRegions()) == 1);
+  // turn 1
+  test_assert("board_tests#1.0", board.canPlaceTile(tile1, 0, 1, 2));
+  board.placeTile(tile1, 0, 1, 2, &meeple_place_candidates);
+  test_assert("board_tests#1.1", meeple_place_candidates.size() == 2);
+  meeple_place_candidates.clear();
+  board.placeMeeple(tile1->getCitySegments()->at(0), MeepleColor::RED);
+  board.endTurn();
+  test_assert("board_tests#1.2", count_unmerged_region<CityRegion>(board.getCityRegions()) == 1);
+  test_assert("board_tests#1.3", count_unmerged_region<CloisterRegion>(board.getCloisterRegions()) == 0);
+  test_assert("board_tests#1.4", count_unmerged_region<FieldRegion>(board.getFieldRegions()) == 3);
+  test_assert("board_tests#1.5", count_unmerged_region<RoadRegion>(board.getRoadRegions()) == 1);
+  test_assert("board_tests#1.6", board.getGameContext()->getTotalPoint(MeepleColor::RED) == 4);
+  test_assert("board_tests#1.7", board.getGameContext()->getTotalPoint(MeepleColor::GREEN) == 0);
+  test_assert("board_tests#1.8", board.getGameContext()->getHoldingMeepleCount(MeepleColor::RED) == 7);
+  test_assert("board_tests#1.9", board.getGameContext()->getHoldingMeepleCount(MeepleColor::GREEN) == 7);
+
+  // turn 2(skip)
+  test_assert("board_tests#2.0", !board.hasPossiblePlacement(tile2));
+
+  // turn 3
+  test_assert("board_tests#3.0", board.canPlaceTile(tile3, 1, 1, 0));
+  board.placeTile(tile3, 1, 1, 0, &meeple_place_candidates);
+  test_assert("board_tests#3.1", meeple_place_candidates.size() == 2);
+  meeple_place_candidates.clear();
+  board.placeMeeple(tile3->getCloisterSegment(), MeepleColor::GREEN);
+  board.endTurn();
+  test_assert("board_tests#3.2", count_unmerged_region<CityRegion>(board.getCityRegions()) == 1);
+  test_assert("board_tests#3.3", count_unmerged_region<CloisterRegion>(board.getCloisterRegions()) == 1);
+  test_assert("board_tests#3.4", count_unmerged_region<FieldRegion>(board.getFieldRegions()) == 3);
+  test_assert("board_tests#3.5", count_unmerged_region<RoadRegion>(board.getRoadRegions()) == 1);
+  test_assert("board_tests#3.6", board.getGameContext()->getTotalPoint(MeepleColor::RED) == 4);
+  test_assert("board_tests#3.7", board.getGameContext()->getTotalPoint(MeepleColor::GREEN) == 0);
+  test_assert("board_tests#3.8", board.getGameContext()->getHoldingMeepleCount(MeepleColor::RED) == 7);
+  test_assert("board_tests#3.9", board.getGameContext()->getHoldingMeepleCount(MeepleColor::GREEN) == 6);
+
+  // turn 4
+  test_assert("board_tests#4.0", board.canPlaceTile(tile4, -1, 0, 1));
+  board.placeTile(tile4, -1, 0, 1, &meeple_place_candidates);
+  board.endTurn();
+  test_assert("board_tests#4.1", meeple_place_candidates.size() == 3);
+  meeple_place_candidates.clear();
+  board.endTurn();
+  test_assert("board_tests#4.2", count_unmerged_region<CityRegion>(board.getCityRegions()) == 1);
+  test_assert("board_tests#4.3", count_unmerged_region<CloisterRegion>(board.getCloisterRegions()) == 1);
+  test_assert("board_tests#4.4", count_unmerged_region<FieldRegion>(board.getFieldRegions()) == 3);
+  test_assert("board_tests#4.5", count_unmerged_region<RoadRegion>(board.getRoadRegions()) == 1);
+  test_assert("board_tests#4.6", board.getGameContext()->getTotalPoint(MeepleColor::RED) == 4);
+  test_assert("board_tests#4.7", board.getGameContext()->getTotalPoint(MeepleColor::GREEN) == 0);
+  test_assert("board_tests#4.8", board.getGameContext()->getHoldingMeepleCount(MeepleColor::RED) == 7);
+  test_assert("board_tests#4.9", board.getGameContext()->getHoldingMeepleCount(MeepleColor::GREEN) == 6);
+
+  test_assert("board_tests#5.0", board.isUndoable());
+  tile = board.undo(); // turn4を取り消し
+  test_assert("board_tests#5.1", tile == tile4);
+  test_assert("board_tests#5.2", board.isUndoable());
+  tile = board.undo(); // turn3を取り消し
+  test_assert("board_tests#5.3", tile == tile3);
+  test_assert("board_tests#5.4", board.isUndoable());
+  tile = board.undo(); // turn1を取り消し
+  test_assert("board_tests#5.5", !board.isUndoable());
+
+  test_assert("board_tests#6.0", count_unmerged_region<CityRegion>(board.getCityRegions()) == 1);
+  test_assert("board_tests#6.1", count_unmerged_region<CloisterRegion>(board.getCloisterRegions()) == 0);
+  test_assert("board_tests#6.2", count_unmerged_region<FieldRegion>(board.getFieldRegions()) == 2);
+  test_assert("board_tests#6.3", count_unmerged_region<RoadRegion>(board.getRoadRegions()) == 1);
+  test_assert("board_tests#6.4", board.getGameContext()->getTotalPoint(MeepleColor::RED) == 0);
+  test_assert("board_tests#6.5", board.getGameContext()->getTotalPoint(MeepleColor::GREEN) == 0);
+  test_assert("board_tests#6.6", board.getGameContext()->getHoldingMeepleCount(MeepleColor::RED) == 7);
+  test_assert("board_tests#6.7", board.getGameContext()->getHoldingMeepleCount(MeepleColor::GREEN) == 7);
 
   delete tile0;
   delete tile1;

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -1,6 +1,7 @@
 #include <cstdlib>
 #include <set>
 
+#include "board.hpp"
 #include "game_context.hpp"
 #include "meeple_color.hpp"
 #include "region.hpp"

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -193,7 +193,7 @@ void city_region_tests() {
 
 
 void cloister_region_tests() {
-  Board board(10);
+  Board board(10, 7);
   Segment s(0, SegmentType::CLOISTER, false);
   Tile tile(0);
   tile.setX(0).setY(0).setRotation(0);
@@ -409,10 +409,9 @@ void game_context_tests() {
 void board_tests() {
   TileFactory tile_factory;
   tile_factory.loadResource("tiles.json");
-  Board board(20);
-  GameContext context(7);
-  context.registerMeeple(MeepleColor::RED);
-  context.registerMeeple(MeepleColor::GREEN);
+  Board board(20, 7);
+  board.registerMeeple(MeepleColor::RED);
+  board.registerMeeple(MeepleColor::GREEN);
   std::vector<Segment*> meeple_place_candidates;
 
   Tile* tile0 = tile_factory.newFromName("D", 0);
@@ -423,16 +422,16 @@ void board_tests() {
 
   board.setInitialTile(tile0, 3);
   test_assert("board_tests#0", board.canPlaceTile(tile1, 0, 1, 2));
-  board.placeTile(tile1, 0, 1, 2, &meeple_place_candidates, &context);
+  board.placeTile(tile1, 0, 1, 2, &meeple_place_candidates);
   test_assert("board_tests#1", meeple_place_candidates.size() == 2);
   meeple_place_candidates.clear();
   test_assert("board_tests#2", !board.hasPossiblePlacement(tile2));
   test_assert("board_tests#3", board.canPlaceTile(tile3, 1, 1, 0));
-  board.placeTile(tile3, 1, 1, 0, &meeple_place_candidates, &context);
+  board.placeTile(tile3, 1, 1, 0, &meeple_place_candidates);
   test_assert("board_tests#4", meeple_place_candidates.size() == 2);
   meeple_place_candidates.clear();
   test_assert("board_tests#5", board.canPlaceTile(tile4, -1, 0, 1));
-  board.placeTile(tile4, -1, 0, 1, &meeple_place_candidates, &context);
+  board.placeTile(tile4, -1, 0, 1, &meeple_place_candidates);
   test_assert("board_tests#6", meeple_place_candidates.size() == 3);
   meeple_place_candidates.clear();
 

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -98,6 +98,53 @@ void segment_tests() {
   segment_is_adjacent_to_tests(&tile_factory);
 }
 
+int count_region_segments(Region* region) {
+  int count = 0;
+  for (auto it = region->segmentBegin(); it != region->segmentEnd(); ++it) {
+    count++;
+  }
+  return count;
+}
+
+void region_iterator_tests() {
+  Segment s0(0, SegmentType::CITY, false);
+  Segment s1(1, SegmentType::CITY, false);
+  Segment s2(2, SegmentType::CITY, false);
+  Segment s3(3, SegmentType::CITY, false);
+  Segment s4(4, SegmentType::CITY, false);
+  Segment s5(5, SegmentType::CITY, false);
+  Segment s6(6, SegmentType::CITY, false);
+  Segment s7(7, SegmentType::CITY, false);
+  Segment s8(8, SegmentType::CITY, false);
+  CityRegion r0(0, &s0, nullptr);
+  CityRegion r1(1, &s3, nullptr);
+  CityRegion r2(2, &s4, nullptr);
+  CityRegion r3(3, &s6, nullptr);
+
+  r0.addSegment(&s1);
+  r0.addSegment(&s2);
+  r2.addSegment(&s5);
+  r3.addSegment(&s7);
+  r3.addSegment(&s8);
+  test_assert("region_iterator_tests#0", count_region_segments(&r0) == 3);
+  test_assert("region_iterator_tests#1", count_region_segments(&r1) == 1);
+  test_assert("region_iterator_tests#2", count_region_segments(&r2) == 2);
+  test_assert("region_iterator_tests#3", count_region_segments(&r3) == 3);
+  r2.mergeRegion(&r3);
+  test_assert("region_iterator_tests#4", count_region_segments(&r2) == 5);
+  r0.mergeRegion(&r1);
+  test_assert("region_iterator_tests#5", count_region_segments(&r0) == 4);
+  r0.mergeRegion(&r2);
+  test_assert("region_iterator_tests#6", count_region_segments(&r0) == 9);
+  test_assert("region_iterator_tests#7", count_region_segments(&r1) == 1);
+  test_assert("region_iterator_tests#8", count_region_segments(&r2) == 5);
+  test_assert("region_iterator_tests#9", count_region_segments(&r3) == 3);
+  r0.undoMergeRegion(&r2);
+  test_assert("region_iterator_tests#10", count_region_segments(&r0) == 4);
+  r0.undoMergeRegion(&r1);
+  test_assert("region_iterator_tests#11", count_region_segments(&r0) == 3);
+}
+
 void cup_city_region_tests(TileFactory* tile_factory) {
   Tile* tile0 = tile_factory->newFromName("E", 0);
   Tile* tile1 = tile_factory->newFromName("E", 1);
@@ -488,6 +535,7 @@ void tests() {
   tile_position_map_tests();
   tile_tests();
   segment_tests();
+  region_iterator_tests();
   cloister_region_tests();
   city_region_tests();
   field_region_tests();

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -15,6 +15,7 @@ void tile_position_map_tests() {
   TilePositionMap m(10);
   Tile tile1(0);
   Tile tile2(1);
+  Tile* tp;
   const std::set<BoardPosition>* s;
 
   test_assert("tile_position_map_tests#0", !m.isTilePlaced(0, 0));
@@ -31,6 +32,11 @@ void tile_position_map_tests() {
   test_assert("tile_position_map_tests#7", m.getPlacedTile(1, 0) == &tile2);
   s = m.getPlacablePositions();
   test_assert("tile_position_map_tests#8", s->size() == 6);
+  tp = m.undo(1, 0);
+  test_assert("tile_position_map_tests#9", tp == &tile2);
+  test_assert("tile_position_map_tests#10", !m.isTilePlaced(1, 0));
+  s = m.getPlacablePositions();
+  test_assert("tile_position_map_tests#11", s->size() == 4);
 }
 
 void tile_get_border_type_tests(TileFactory* tile_factory) {

--- a/unit_tests.cpp
+++ b/unit_tests.cpp
@@ -460,6 +460,18 @@ void game_context_tests() {
   test_assert("game_context_tests#2.17", context.getGainedPoint(MeepleColor::GREEN, RegionType::FIELD) == 0);
 }
 
+template <typename R>
+int count_unmerged_region(const std::vector<R*>* regions) {
+  int region_count = 0;
+  for (auto it = regions->begin(); it != regions->end(); it++) {
+    R* r = *it;
+    if (!r->isMerged()) {
+      region_count++;
+    }
+  }
+  return region_count;
+}
+
 void board_tests() {
   TileFactory tile_factory;
   tile_factory.loadResource("tiles.json");
@@ -489,46 +501,10 @@ void board_tests() {
   test_assert("board_tests#6", meeple_place_candidates.size() == 3);
   meeple_place_candidates.clear();
 
-  int region_count = 0;
-  const std::vector<CityRegion*>* city_regions = board.getCityRegions();
-  for (auto it = city_regions->begin(); it != city_regions->end(); it++) {
-    CityRegion* r = *it;
-    if (!r->isMerged()) {
-      region_count++;
-    }
-  }
-  test_assert("board_tests#7", region_count == 1);
-
-  region_count = 0;
-  const std::vector<CloisterRegion*>* cloister_regions = board.getCloisterRegions();
-  for (auto it = cloister_regions->begin(); it != cloister_regions->end(); it++) {
-    CloisterRegion* r = *it;
-    if (!r->isMerged()) {
-      region_count++;
-    }
-  }
-  test_assert("board_tests#8", region_count == 1);
-
-  region_count = 0;
-  const std::vector<FieldRegion*>* field_regions = board.getFieldRegions();
-  for (auto it = field_regions->begin(); it != field_regions->end(); it++) {
-    FieldRegion* r = *it;
-    if (!r->isMerged()) {
-      region_count++;
-    }
-  }
-  test_assert("board_tests#9", region_count == 3);
-
-  region_count = 0;
-  const std::vector<RoadRegion*>* road_regions = board.getRoadRegions();
-  for (auto it = road_regions->begin(); it != road_regions->end(); it++) {
-    RoadRegion* r = *it;
-    if (!r->isMerged()) {
-      region_count++;
-    }
-  }
-  test_assert("board_tests#10", region_count == 1);
-  region_count = 0;
+  test_assert("board_tests#7", count_unmerged_region<CityRegion>(board.getCityRegions()) == 1);
+  test_assert("board_tests#8", count_unmerged_region<CloisterRegion>(board.getCloisterRegions()) == 1);
+  test_assert("board_tests#9", count_unmerged_region<FieldRegion>(board.getFieldRegions()) == 3);
+  test_assert("board_tests#10", count_unmerged_region<RoadRegion>(board.getRoadRegions()) == 1);
 
   delete tile0;
   delete tile1;


### PR DESCRIPTION
実装がほぼ完了しました。

- Undo処理の大まかな実装方針
    - Tile配置やMeeple配置によって起こったことを記録しておいて、undo時にはそれを取り消す処理を行う
    - 記録すること
        - 配置したTile
        - Meepleを配置したSegment
        - 新規生成されたRegion
        - マージされたRegion
        - 完成したRegion
- その他
    - undo処理を可能にするため、Regionの構造を大きく変えた
        - マージという処理に関して木構造を形作るようにした
            - 理由：マージに伴うRegion中のSegmentの移し替えをなくすことができ、マージの取り消し処理を行いやすくなる
    - 例のインクルードの問題は、クラスの宣言があれば済む箇所はインクルードをしないことによって回避した(これが良い方法なのかは不明)
    - Boardの実装が大きく変わってしまったので、棋譜読み込みの実装はこちらの実装に合わせます。
        - このPRがマージされた後にPR出します。(一応、前のBoardを元にした実装は[score-sheet](https://github.com/sash2104/carcassonne/tree/score-sheet)というブランチにある)


残作業

- テストの追加
- バグ修正(あれば)
- リファクタリング
- コメント追加